### PR TITLE
Remove hero tagline and stats from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,21 +233,6 @@
     <header id="home">
         <div class="hero-content">
             <h1>中国城市图书馆信息</h1>
-            <p>探索中国各地的图书馆，发现知识的殿堂</p>
-            <div class="hero-stats">
-                <div class="stat-item">
-                    <span class="stat-number">150+</span>
-                    <span class="stat-label">图书馆</span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-number">20+</span>
-                    <span class="stat-label">城市</span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-number">24/7</span>
-                    <span class="stat-label">在线服务</span>
-                </div>
-            </div>
         </div>
         <div id="city-list">
             <h2>选择城市</h2>


### PR DESCRIPTION
## Summary
- remove the hero section tagline text from the homepage
- delete the numeric stats block that displayed library, city, and online service counts

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcad6695048321b58b5f2476d5ccee