### PR TITLE
Align sitemap URLs with canonical domain

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # 网站地图位置
-Sitemap: https://tushuguan.com/sitemap.xml
+Sitemap: https://www.tushuguan.com/sitemap.xml
 
 # 爬取延迟（可选）
 Crawl-delay: 1

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,61 +3,61 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     <url>
-        <loc>https://tushuguan.com/</loc>
+        <loc>https://www.tushuguan.com/</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/bookstores.html</loc>
+        <loc>https://www.tushuguan.com/bookstores.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/cities.html</loc>
+        <loc>https://www.tushuguan.com/cities.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/reading-clubs.html</loc>
+        <loc>https://www.tushuguan.com/reading-clubs.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/tao-te-ching.html</loc>
+        <loc>https://www.tushuguan.com/tao-te-ching.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/bookstore-sanlian-taofen.html</loc>
+        <loc>https://www.tushuguan.com/bookstore-sanlian-taofen.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/bookstore-zhongshuge-shanghai.html</loc>
+        <loc>https://www.tushuguan.com/bookstore-zhongshuge-shanghai.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/bookstore-fangsuo-guangzhou.html</loc>
+        <loc>https://www.tushuguan.com/bookstore-fangsuo-guangzhou.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/bookstore-yanyi-chongqing.html</loc>
+        <loc>https://www.tushuguan.com/bookstore-yanyi-chongqing.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
     </url>
     <url>
-        <loc>https://tushuguan.com/bookstore-tsutaya-hangzhou.html</loc>
+        <loc>https://www.tushuguan.com/bookstore-tsutaya-hangzhou.html</loc>
         <lastmod>2024-10-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>


### PR DESCRIPTION
## Summary
- update every sitemap entry to use the https://www.tushuguan.com origin to match the verified property
- point the robots.txt Sitemap directive at the same canonical sitemap URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deffbb99408321aa8971603179ea77