### PR TITLE
Add Hotspot Game link to navigation menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,9 @@
                     <a href="#games" class="navbar-link" data-section="games">小游戏</a>
                 </li>
                 <li class="navbar-item">
+                    <a href="https://hotspotgame.online/" class="navbar-link" target="_blank" rel="noopener noreferrer">热点游戏</a>
+                </li>
+                <li class="navbar-item">
                     <a href="#about" class="navbar-link" data-section="about">关于我们</a>
                 </li>
                 <li class="navbar-item">
@@ -199,6 +202,9 @@
                 </li>
                 <li class="mobile-nav-item">
                     <a href="#games" class="mobile-nav-link" data-section="games">小游戏</a>
+                </li>
+                <li class="mobile-nav-item">
+                    <a href="https://hotspotgame.online/" class="mobile-nav-link" target="_blank" rel="noopener noreferrer">热点游戏</a>
                 </li>
                 <li class="mobile-nav-item">
                     <a href="#about" class="mobile-nav-link" data-section="about">关于我们</a>


### PR DESCRIPTION
## Summary
- add a "热点游戏" navigation item to the desktop menu that opens hotspotgame.online in a new tab
- mirror the hotspot game link in the mobile navigation menu for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c222399c8321891db9851a5481c7